### PR TITLE
Clonsdale update bluetooth keyboard threading

### DIFF
--- a/BluetoothChat/BluetoothChatService.cs
+++ b/BluetoothChat/BluetoothChatService.cs
@@ -398,7 +398,7 @@ namespace BluetoothChat
 				// Get a BluetoothSocket for a connection with the
 				// given BluetoothDevice
 				try {
-					tmp = _adapter.ListenUsingRfcommWithServiceRecord (NAME, MY_UUID);
+					tmp = device.CreateRfcommSocketToServiceRecord (MY_UUID);
 
 				} catch (Java.IO.IOException e) {
 					Log.Error (TAG, "create() failed", e);

--- a/BluetoothChat/BluetoothChatService.cs
+++ b/BluetoothChat/BluetoothChatService.cs
@@ -308,7 +308,6 @@ namespace BluetoothChat
 				// Create a new listening server socket
 				try {
 					tmp = _adapter.ListenUsingRfcommWithServiceRecord (NAME, MY_UUID);
-	
 				} catch (Java.IO.IOException e) {
 					Log.Error (TAG, "listen() failed", e);
 				}
@@ -336,8 +335,7 @@ namespace BluetoothChat
 					}
 					
 					// If a connection was accepted
-					if (socket != null) 
-					{
+					if (socket != null) {
 						lock (this) {
 							switch (_state) {
 							case STATE_LISTEN:
@@ -400,9 +398,8 @@ namespace BluetoothChat
 				// Get a BluetoothSocket for a connection with the
 				// given BluetoothDevice
 				try {
+					tmp = _adapter.ListenUsingRfcommWithServiceRecord (NAME, MY_UUID);
 
-					var methodInfo = device.GetType().GetMethod("CreateRfcommSocketToServiceRecord");//, new Class[] {int.class});
-					tmp = (BluetoothSocket) methodInfo.Invoke(device, new object[]{MY_UUID});
 				} catch (Java.IO.IOException e) {
 					Log.Error (TAG, "create() failed", e);
 				}


### PR DESCRIPTION
Updated the threading in BluetoothChatService.cs to use System.Threading.Thread rather than Java.Lang.Thread.

I have also updated the method of getting the CreateRfcommSocketToServiceRecord method.
A lot of people have had issue getting the ConnectThread to work and have been using the following work around it with the following method:
http://lists.ximian.com/pipermail/monodroid/2012-September/012376.html

I've updated to use a similar method. 