### PR TITLE
Fixes exception in DemoActivity.OnDestroy.

### DIFF
--- a/ServiceSamples/DemoService/DemoService/DemoActivity.cs
+++ b/ServiceSamples/DemoService/DemoService/DemoActivity.cs
@@ -62,7 +62,7 @@ namespace DemoService
 
 			var demoServiceIntent = new Intent ("com.xamarin.DemoService");
 			demoServiceConnection = new DemoServiceConnection (this);
-			ApplicationContext.BindService (demoServiceIntent, demoServiceConnection, Bind.AutoCreate);
+			BindService (demoServiceIntent, demoServiceConnection, Bind.AutoCreate);
 		}
 
 		protected override void OnDestroy ()


### PR DESCRIPTION
The bug was that the BindService and UnbindService calls were unmatched. Bind was called on ApplicationContext whereas UnbindService was called on the Activity.
