### PR TITLE
FIxed CameraAppDemo Folder Exists logic

### DIFF
--- a/CameraAppDemo/MainActivity.cs
+++ b/CameraAppDemo/MainActivity.cs
@@ -65,7 +65,7 @@ namespace CameraAppDemo
         private void CreateDirectoryForPictures()
         {
             _dir = new File(Environment.GetExternalStoragePublicDirectory(Environment.DirectoryPictures), "CameraAppDemo");
-            if (_dir.Exists())
+            if (!_dir.Exists())
             {
                 _dir.Mkdirs();
             }


### PR DESCRIPTION
The CreateDirectoryForPictures function did not negate the Exists() method when trying to create the directory.
