### PR TITLE
[KitKat] Correct HCE permission, action, metadata

### DIFF
--- a/KitKat/KitKat/HceService.cs
+++ b/KitKat/KitKat/HceService.cs
@@ -6,9 +6,9 @@ using Android.Nfc.CardEmulators;
 namespace KitKat
 {
 	// Setup for an NFC HCE payments application 
-	[Service(Exported=true, Permission="android.permissions.BIND_NFC_SERVICE"), 
-		IntentFilter(new[] {"android.nfc.cardemulation.HOST_APDU_SERVICE"}), 
-		MetaData("andorid.nfc.cardemulation.host.apdu_service", 
+	[Service(Exported=true, Permission=Android.Manifest.Permission.BindNfcService),
+		IntentFilter(new[] { HostApduService.ServiceInterface }),
+		MetaData(HostApduService.ServiceMetaData,
 			Resource="@xml/hceservice")]
 
 	// The hceservice.xml resource contains important information for pairing the HCE Service


### PR DESCRIPTION
Switch the Permission, IntentFilter, and MetaData attributes to use the
built-in named string constants. This fixes some problems caused by
typos in the hand-typed strings. After these corrections, the "Xamarin"
service_banner.png drawable will appear correctly under the top-level
"Tap & pay" entry in the Android Settings menu when the app is
installed.

The correct Permission is:
Android.Manifest.Permission.BindNfcService ==
"android.permission.BIND_NFC_SERVICE"

The correct action in the IntentFilter is:
HostApduService.ServiceInterface ==
"android.nfc.cardemulation.action.HOST_APDU_SERVICE"

The correct MetaData name is:
HostApduService.ServiceMetaData ==
"android.nfc.cardemulation.host_apdu_service"

If the Permission is incorrect, the system will output an error to the
logcat log during app installation:

> E/RegisteredServicesCache: Skipping APDU service
> ComponentInfo{KitKat.KitKat/kitkat.HceService}: it does not require
> the permission android.permission.BIND_NFC_SERVICE

If the MetaData name is incorrect, the system will output a warning to
the logcat log during app installation:

> W/RegisteredServicesCache: Unable to load component info
> ResolveInfo{654f9948 KitKat.KitKat/kitkat.HceService m=0x108000}
> 
> W/RegisteredServicesCache: org.xmlpull.v1.XmlPullParserException: No
> android.nfc.cardemulation.host_apdu_service meta-data

If all three attributes are correct, the system will automatically start
the service once it's installed:

> I/ActivityManager: Start proc KitKat.KitKat for service
> KitKat.KitKat/kitkat.HceService
