### PR TITLE
Don't use string constants for class names.

### DIFF
--- a/SimpleWidget/UpdateService.cs
+++ b/SimpleWidget/UpdateService.cs
@@ -32,7 +32,7 @@ namespace SimpleWidget
 			RemoteViews updateViews = buildUpdate (this);
 
 			// Push update for this widget to the home screen
-			ComponentName thisWidget = new ComponentName (this, "simplewidget.WordWidget");
+			ComponentName thisWidget = new ComponentName (this, Java.Lang.Class.FromType (typeof (WordWidget)).Name);
 			AppWidgetManager manager = AppWidgetManager.GetInstance (this);
 			manager.UpdateAppWidget (thisWidget, updateViews);
 		}


### PR DESCRIPTION
This allows the SimpleWidget sample to run as expected when built
with Xamarin.Android 5.0+.

Strings containing type names are bad. They break refactoring.

They also cause things to break when we change the names of the
generated Android Callable Wrappers:

  http://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#Android_Callable_Wrapper_Naming

As is often the case, Don't Do That™.

Specifically, work *with* type system, and use actual types instead
of strings.