### PR TITLE
BluetoothLeGatt Sample

### DIFF
--- a/BluetoothLeGatt/DeviceControlActivity.cs
+++ b/BluetoothLeGatt/DeviceControlActivity.cs
@@ -49,8 +49,8 @@ namespace BluetoothLeGatt
 		public static String mDeviceAddress;
 		ExpandableListView mGattServicesList;
 		public static BluetoothLeService mBluetoothLeService;
-		List <List <BluetoothGattCharacteristic>> mGattCharacteristics =
-			new List <List <BluetoothGattCharacteristic>> ();
+		List <IList <BluetoothGattCharacteristic>> mGattCharacteristics =
+			new List <IList <BluetoothGattCharacteristic>> ();
 		public static bool mConnected = false;
 		BluetoothGattCharacteristic mNotifyCharacteristic;
 
@@ -194,54 +194,50 @@ namespace BluetoothLeGatt
 			String uuid = null;
 			String unknownServiceString = Resources.GetString (Resource.String.unknown_service);
 			String unknownCharaString = Resources.GetString (Resource.String.unknown_characteristic);
-			List <Dictionary <String, Object>> gattServiceData = new List <Dictionary <String, Object>> ();
-			List <List <Dictionary <String, String>>> gattCharacteristicData
-				= new List <List <Dictionary <String, String>>> ();
-			mGattCharacteristics = new List <List <BluetoothGattCharacteristic>> ();
+			IList <IDictionary <string, object>> gattServiceData = new JavaList <IDictionary <string, object>> ();
+			IList <IList <IDictionary <string, object>>> gattCharacteristicData
+			= new JavaList <IList <IDictionary <string, object>>> ();
+			mGattCharacteristics = new List <IList <BluetoothGattCharacteristic>> ();
 
 			// Loops through available GATT Services.
 			foreach (BluetoothGattService gattService in gattServices) {
-				Dictionary <String, Object> currentServiceData = new Dictionary <String, Object>();
+				IDictionary <string, object> currentServiceData = new JavaDictionary <string, object>();
 				uuid = gattService.Uuid.ToString ();
-				currentServiceData.Add (
-					LIST_NAME, SampleGattAttributes.Lookup (uuid, unknownServiceString));
+				currentServiceData.Add (LIST_NAME, SampleGattAttributes.Lookup (uuid, unknownServiceString));
 				currentServiceData.Add (LIST_UUID, uuid);
 				gattServiceData.Add (currentServiceData);
 
-				List <Dictionary <String, String>> gattCharacteristicGroupData =
-					new List <Dictionary <String, String>>();
-				IList <BluetoothGattCharacteristic> gattCharacteristics =
-					gattService.Characteristics;
-				List <BluetoothGattCharacteristic> charas =
-					new List<BluetoothGattCharacteristic> ();
+				IList <IDictionary <string, object>> gattCharacteristicGroupData =new JavaList <IDictionary <string, object>>();
+				IList <BluetoothGattCharacteristic> gattCharacteristics =gattService.Characteristics;
+				IList <BluetoothGattCharacteristic> charas =new List<BluetoothGattCharacteristic> ();
 
 				// Loops through available Characteristics.
 				foreach (BluetoothGattCharacteristic gattCharacteristic in gattCharacteristics) {
 					charas.Add (gattCharacteristic);
-					Dictionary <String, String> currentCharaData = new Dictionary <String, String>();
+					IDictionary <string, object> currentCharaData = new JavaDictionary <string, object>();
 					uuid = gattCharacteristic.Uuid.ToString();
-					currentCharaData.Add (
-						LIST_NAME, SampleGattAttributes.Lookup(uuid, unknownCharaString));
+					currentCharaData.Add (LIST_NAME, SampleGattAttributes.Lookup(uuid, unknownCharaString));
 					currentCharaData.Add (LIST_UUID, uuid);
 					gattCharacteristicGroupData.Add (currentCharaData);
 				}
 				mGattCharacteristics.Add (charas);
 				gattCharacteristicData.Add (gattCharacteristicGroupData);
 			}
-
-			SimpleExpandableListAdapter gattServiceAdapter = new SimpleExpandableListAdapter (
+			var groupData=(IList<IDictionary<string,object>>) gattServiceData;
+			var childData =(IList <IList <IDictionary <string, object>>>) gattCharacteristicData;
+			IExpandableListAdapter gattServiceAdapter = new SimpleExpandableListAdapter (
 				this,
-				(IList<IDictionary<String, Object>>) gattServiceData,
+				groupData,
 				Android.Resource.Layout.SimpleExpandableListItem2,
 				new String[] {LIST_NAME, LIST_UUID},
 				new int[] { Android.Resource.Id.Text1, Android.Resource.Id.Text2 },
-				(IList<IList<IDictionary<String, Object>>>) gattCharacteristicData,
+				childData,
 				Android.Resource.Layout.SimpleExpandableListItem2,
 				new String[] {LIST_NAME, LIST_UUID},
 				new int[] { Android.Resource.Id.Text1, Android.Resource.Id.Text2 }
 			);
 
-			mGattServicesList.Adapter = (IListAdapter) gattServiceAdapter;
+			mGattServicesList.SetAdapter (gattServiceAdapter);
 		}
 
 		private static IntentFilter MakeGattUpdateIntentFilter () 

--- a/BluetoothLeGatt/DeviceScanActivity.cs
+++ b/BluetoothLeGatt/DeviceScanActivity.cs
@@ -24,6 +24,7 @@ using Android.OS;
 using Android.Bluetooth;
 using System.Collections.Generic;
 using System.Threading;
+using System.Linq;
 
 namespace BluetoothLeGatt
 {
@@ -199,8 +200,10 @@ namespace BluetoothLeGatt
 
 		public void AddDevice (BluetoothDevice device) 
 		{
-			if (!mLeDevices.Contains (device)) {
-				mLeDevices.Add (device);
+			lock (this) {
+				if (mLeDevices.Where (d => d.Address == device.Address).FirstOrDefault () == null) {
+					mLeDevices.Add (device);
+				}
 			}
 		}
 

--- a/BluetoothLeGatt/SampleGattAttributes.cs
+++ b/BluetoothLeGatt/SampleGattAttributes.cs
@@ -32,24 +32,24 @@ namespace BluetoothLeGatt
  	*/
 	public class SampleGattAttributes
 	{
-		public static String HEART_RATE_MEASUREMENT = "00002a37-0000-1000-8000-00805f9b34fb";
-		public static String CLIENT_CHARACTERISTIC_CONFIG = "00002902-0000-1000-8000-00805f9b34fb";
+		public static string HEART_RATE_MEASUREMENT = "00002a37-0000-1000-8000-00805f9b34fb";
+		public static string CLIENT_CHARACTERISTIC_CONFIG = "00002902-0000-1000-8000-00805f9b34fb";
 
-		private static Dictionary <String, String> Attributes = new Dictionary <String, String> ()
-		{
+		private static Dictionary <string, string> Attributes = new Dictionary <string, string> () {
 			// Sample Services.
-			{"0000180d-0000-1000-8000-00805f9b34fb", "Heart Rate Service"},
-			{"0000180a-0000-1000-8000-00805f9b34fb", "Device Information Service"},
+			{ "0000180d-0000-1000-8000-00805f9b34fb", "Heart Rate Service" },
+			{ "0000180a-0000-1000-8000-00805f9b34fb", "Device Information Service" },
 
 			// Sample Characteristics.
-			{HEART_RATE_MEASUREMENT, "Heart Rate Measurement"},
-			{"00002a29-0000-1000-8000-00805f9b34fb", "Manufacturer Name String"},
+			{ HEART_RATE_MEASUREMENT, "Heart Rate Measurement" },
+			{ "00002a29-0000-1000-8000-00805f9b34fb", "Manufacturer Name String" },
 		};
 
-		public static String Lookup (String key, String defaultName) 
+		public static string Lookup (string key, string defaultName)
 		{
-			String name = Attributes [key];
-			return name == null ? defaultName : name;
+			if (Attributes.ContainsKey (key))
+				return Attributes [key];
+			return defaultName;
 		}
 	}
 }


### PR DESCRIPTION
Fixes:

-Converted to JavaList and JavaDictionary to work with the ExpandableList
-Use SetAdapter instead of Adapter property
-Filter the already added devices OnLeScan using bluetooth address and not the object itself to avoid adding the same device more than once
-Modified the method Lookup in SampleGattAttributes that was crashing the application

Improvments:
-When manually disconnecting from a device I am also closing the connection (trying to reuse the connection on some devices will take almost one minute to have the connection established again)
