### PR TITLE
FIX: Incorrect UTC timestamp offset

### DIFF
--- a/UrbanAirship/samples/RichPushSample/Sources/Widget/RichPushWidgetUtils.cs
+++ b/UrbanAirship/samples/RichPushSample/Sources/Widget/RichPushWidgetUtils.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Samples.UrbanAirship.RichPush
 			if (delayInMs > 0) {
 				PendingIntent pendingIntent = PendingIntent.GetBroadcast(context, 0, refreshIntent, 0);
 				AlarmManager am = (AlarmManager) context.GetSystemService(Context.AlarmService);
-				am.Set (AlarmType.RtcWakeup, (long) new TimeSpan (DateTime.Now.Ticks).TotalMilliseconds + delayInMs, pendingIntent);
+				am.Set (AlarmType.RtcWakeup, Java.Lang.JavaSystem.CurrentTimeMillis() + delayInMs, pendingIntent);
 			} else {
 				context.SendBroadcast(refreshIntent);
 			}


### PR DESCRIPTION
First of all, DateTime.Now is local, and RtcWakeup expects the time to be UTC.
Secondly, it creates a timestamp relative to January 1, 0001, when AlarmManager expects it to be since the January 1, 1970.

Using currentTimeMillis() fixes this as intended.

See https://forums.xamarin.com/discussion/20158/create-utc-date-for-alarmmanager-from-date-in-local-timezone