### PR TITLE
Fixes Support v7 Toolbar sample to show popup themes

### DIFF
--- a/Supportv7/AppCompat/Toolbar/Supportv7Toolbar/Resources/layout/Main.axml
+++ b/Supportv7/AppCompat/Toolbar/Supportv7Toolbar/Resources/layout/Main.axml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorAccent"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            android:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+            local:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            local:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
     </LinearLayout>
 </RelativeLayout>

--- a/Supportv7/AppCompat/Toolbar/Supportv7Toolbar/Resources/layout/toolbar.axml
+++ b/Supportv7/AppCompat/Toolbar/Supportv7Toolbar/Resources/layout/toolbar.axml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:local="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-    android:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    local:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    local:popupTheme="@style/ThemeOverlay.AppCompat.Light" />


### PR DESCRIPTION
Added the needed namespace to make the Toolbar element render the correct theme for the popup

The namespace wasn't defined, so the popupTheme wasn't being respected (as you can see from the photo below)

![genymotion_for_personal_use_-_google_nexus_7_-_4 1_2015-09-02_19-27-44](https://cloud.githubusercontent.com/assets/954102/9647335/f7210fc8-51a9-11e5-865d-1c70c4f9b19f.jpg)

Although the [Light theme was chosen](https://github.com/xamarin/monodroid-samples/pull/94/files#diff-e02c09c46fdb053e70a235933e442704L9), the popup always rendered as the Dark theme.
Now the popup theme is rendered correctly.

![genymotion_for_personal_use_-_google_nexus_7_-_4 1_2015-09-02_19-29-27](https://cloud.githubusercontent.com/assets/954102/9647337/fa4d0d5a-51a9-11e5-9c27-9cb7d33a4d84.jpg)

It took me some time to figure out that the example in the [blog post](https://blog.xamarin.com/android-tips-hello-toolbar-goodbye-action-bar/) was missing this, so I think this might be useful for others developers.