### PR TITLE
Update to Camera2BasicFragment.cs to fix aspect ratio

### DIFF
--- a/android5.0/Camera2Basic/Camera2Basic/Camera2BasicFragment.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Camera2BasicFragment.cs
@@ -388,7 +388,7 @@ namespace Camera2Basic
 			SurfaceOrientation rotation = activity.WindowManager.DefaultDisplay.Rotation;
 			Matrix matrix = new Matrix ();
 			RectF viewRect = new RectF (0, 0, viewWidth, viewHeight);
-			RectF bufferRect = new RectF (0, 0, mPreviewSize.Width, mPreviewSize.Height);
+			RectF bufferRect = new RectF (0, 0, mPreviewSize.Height, mPreviewSize.Width);
 			float centerX = viewRect.CenterX();
 			float centerY = viewRect.CenterY();
 			if (rotation == SurfaceOrientation.Rotation90 || rotation == SurfaceOrientation.Rotation270) {


### PR DESCRIPTION
When I run the example in landscape on my Moto X, I find that the preview appears to be shown in the wrong aspect ration, meaning rather then filling the screen, the image appears to be squished in width, and stretched vertically, going off of the screen.    

After much mucking about, I found that I needed to swap the height and width used for the creation of the bufferRect in the ConfigureTransform method... and then it worked as expected
