### PR TITLE
Fix #156

### DIFF
--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/Camera2BasicSurfaceTextureListener.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/Camera2BasicSurfaceTextureListener.cs
@@ -1,20 +1,21 @@
-
 using Android.Views;
 
 namespace Camera2Basic.Listeners
 {
     public class Camera2BasicSurfaceTextureListener : Java.Lang.Object, TextureView.ISurfaceTextureListener
     {
-        public Camera2BasicFragment Owner { get; set; }
+        private readonly Camera2BasicFragment owner;
 
         public Camera2BasicSurfaceTextureListener(Camera2BasicFragment owner)
         {
-            Owner = owner;
+            if (owner == null)
+                throw new System.ArgumentNullException("owner");
+            this.owner = owner;
         }
 
         public void OnSurfaceTextureAvailable(Android.Graphics.SurfaceTexture surface, int width, int height)
         {
-            Owner.OpenCamera(width, height);
+            owner.OpenCamera(width, height);
         }
 
         public bool OnSurfaceTextureDestroyed(Android.Graphics.SurfaceTexture surface)
@@ -24,7 +25,7 @@ namespace Camera2Basic.Listeners
 
         public void OnSurfaceTextureSizeChanged(Android.Graphics.SurfaceTexture surface, int width, int height)
         {
-            Owner.ConfigureTransform(width, height);
+            owner.ConfigureTransform(width, height);
         }
 
         public void OnSurfaceTextureUpdated(Android.Graphics.SurfaceTexture surface)

--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureListener.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureListener.cs
@@ -1,4 +1,3 @@
-
 using Android.Hardware.Camera2;
 using Java.IO;
 using Java.Lang;
@@ -7,8 +6,15 @@ namespace Camera2Basic.Listeners
 {
     public class CameraCaptureListener : CameraCaptureSession.CaptureCallback
     {
-        public Camera2BasicFragment Owner { get; set; }
-        public File File { get; set; }
+        private readonly Camera2BasicFragment owner;
+
+        public CameraCaptureListener(Camera2BasicFragment owner)
+        {
+            if (owner == null)
+                throw new System.ArgumentNullException("owner");
+            this.owner = owner;
+        }
+
         public override void OnCaptureCompleted(CameraCaptureSession session, CaptureRequest request, TotalCaptureResult result)
         {
             Process(result);
@@ -21,14 +27,14 @@ namespace Camera2Basic.Listeners
 
         private void Process(CaptureResult result)
         {
-            switch (Owner.mState)
+            switch (owner.mState)
             {
                 case Camera2BasicFragment.STATE_WAITING_LOCK:
                     {
                         Integer afState = (Integer)result.Get(CaptureResult.ControlAfState);
                         if (afState == null)
                         {
-                            Owner.CaptureStillPicture();
+                            owner.CaptureStillPicture();
                         }
 
                         else if ((((int)ControlAFState.FocusedLocked) == afState.IntValue()) ||
@@ -39,12 +45,12 @@ namespace Camera2Basic.Listeners
                             if (aeState == null ||
                                     aeState.IntValue() == ((int)ControlAEState.Converged))
                             {
-                                Owner.mState = Camera2BasicFragment.STATE_PICTURE_TAKEN;
-                                Owner.CaptureStillPicture();
+                                owner.mState = Camera2BasicFragment.STATE_PICTURE_TAKEN;
+                                owner.CaptureStillPicture();
                             }
                             else
                             {
-                                Owner.RunPrecaptureSequence();
+                                owner.RunPrecaptureSequence();
                             }
                         }
                         break;
@@ -57,7 +63,7 @@ namespace Camera2Basic.Listeners
                                 aeState.IntValue() == ((int)ControlAEState.Precapture) ||
                                 aeState.IntValue() == ((int)ControlAEState.FlashRequired))
                         {
-                            Owner.mState = Camera2BasicFragment.STATE_WAITING_NON_PRECAPTURE;
+                            owner.mState = Camera2BasicFragment.STATE_WAITING_NON_PRECAPTURE;
                         }
                         break;
                     }
@@ -67,8 +73,8 @@ namespace Camera2Basic.Listeners
                         Integer aeState = (Integer)result.Get(CaptureResult.ControlAeState);
                         if (aeState == null || aeState.IntValue() != ((int)ControlAEState.Precapture))
                         {
-                            Owner.mState = Camera2BasicFragment.STATE_PICTURE_TAKEN;
-                            Owner.CaptureStillPicture();
+                            owner.mState = Camera2BasicFragment.STATE_PICTURE_TAKEN;
+                            owner.CaptureStillPicture();
                         }
                         break;
                     }

--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureSessionCallback.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureSessionCallback.cs
@@ -1,43 +1,44 @@
-
 using Android.Hardware.Camera2;
 
 namespace Camera2Basic.Listeners
 {
     public class CameraCaptureSessionCallback : CameraCaptureSession.StateCallback
     {
-        public Camera2BasicFragment Owner { get; set; }
+        private readonly Camera2BasicFragment owner;
 
         public CameraCaptureSessionCallback(Camera2BasicFragment owner)
         {
-            Owner = owner;
+            if (owner == null)
+                throw new System.ArgumentNullException("owner");
+            this.owner = owner;
         }
 
         public override void OnConfigureFailed(CameraCaptureSession session)
         {
-            Owner.ShowToast("Failed");
+            owner.ShowToast("Failed");
         }
 
         public override void OnConfigured(CameraCaptureSession session)
         {
             // The camera is already closed
-            if (null == Owner.mCameraDevice)
+            if (null == owner.mCameraDevice)
             {
                 return;
             }
 
             // When the session is ready, we start displaying the preview.
-            Owner.mCaptureSession = session;
+            owner.mCaptureSession = session;
             try
             {
                 // Auto focus should be continuous for camera preview.
-                Owner.mPreviewRequestBuilder.Set(CaptureRequest.ControlAfMode, (int)ControlAFMode.ContinuousPicture);
+                owner.mPreviewRequestBuilder.Set(CaptureRequest.ControlAfMode, (int)ControlAFMode.ContinuousPicture);
                 // Flash is automatically enabled when necessary.
-                Owner.SetAutoFlash(Owner.mPreviewRequestBuilder);
+                owner.SetAutoFlash(owner.mPreviewRequestBuilder);
 
                 // Finally, we start displaying the camera preview.
-                Owner.mPreviewRequest = Owner.mPreviewRequestBuilder.Build();
-                Owner.mCaptureSession.SetRepeatingRequest(Owner.mPreviewRequest,
-                        Owner.mCaptureCallback, Owner.mBackgroundHandler);
+                owner.mPreviewRequest = owner.mPreviewRequestBuilder.Build();
+                owner.mCaptureSession.SetRepeatingRequest(owner.mPreviewRequest,
+                        owner.mCaptureCallback, owner.mBackgroundHandler);
             }
             catch (CameraAccessException e)
             {

--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureStillPictureSessionCallback.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureStillPictureSessionCallback.cs
@@ -1,4 +1,3 @@
-
 using Android.Hardware.Camera2;
 using Android.Util;
 
@@ -8,18 +7,22 @@ namespace Camera2Basic.Listeners
     {
         private static readonly string TAG = "CameraCaptureStillPictureSessionCallback";
 
-        public Camera2BasicFragment Owner { get; set; }
+        private readonly Camera2BasicFragment owner;
 
         public CameraCaptureStillPictureSessionCallback(Camera2BasicFragment owner)
         {
-            Owner = owner;
+            if (owner == null)
+                throw new System.ArgumentNullException("owner");
+            this.owner = owner;
         }
 
         public override void OnCaptureCompleted(CameraCaptureSession session, CaptureRequest request, TotalCaptureResult result)
         {
-            Owner.ShowToast("Saved: " + Owner.mFile);
-            Log.Debug(TAG, Owner.mFile.ToString());
-            Owner.UnlockFocus();
+            // If something goes wrong with the save (or the handler isn't even 
+            // registered, this code will toast a success message regardless...)
+            owner.ShowToast("Saved: " + owner.mFile);
+            Log.Debug(TAG, owner.mFile.ToString());
+            owner.UnlockFocus();
         }
     }
 }

--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraStateListener.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraStateListener.cs
@@ -1,4 +1,3 @@
-
 using Android.App;
 using Android.Hardware.Camera2;
 
@@ -6,7 +5,15 @@ namespace Camera2Basic.Listeners
 {
     public class CameraStateListener : CameraDevice.StateCallback
     {
-        public Camera2BasicFragment owner;
+        private readonly Camera2BasicFragment owner;
+
+        public CameraStateListener(Camera2BasicFragment owner)
+        {
+            if (owner == null)
+                throw new System.ArgumentNullException("owner");
+            this.owner = owner;
+        }
+
         public override void OnOpened(CameraDevice cameraDevice)
         {
             // This method is called when the camera is opened.  We start camera preview here.
@@ -34,7 +41,6 @@ namespace Camera2Basic.Listeners
             {
                 activity.Finish();
             }
-
         }
     }
 }

--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/ImageAvailableListener.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/ImageAvailableListener.cs
@@ -1,4 +1,3 @@
-
 using Android.Media;
 using Java.IO;
 using Java.Lang;
@@ -8,11 +7,26 @@ namespace Camera2Basic.Listeners
 {
     public class ImageAvailableListener : Java.Lang.Object, ImageReader.IOnImageAvailableListener
     {
-        public File File { get; set; }
-        public Camera2BasicFragment Owner { get; set; }
+        public ImageAvailableListener(Camera2BasicFragment fragment, File file)
+        {
+            if (fragment == null)
+                throw new System.ArgumentNullException("fragment");
+            if (file == null)
+                throw new System.ArgumentNullException("file");
+
+            owner = fragment;
+            this.file = file;
+        }
+
+        private readonly File file;
+        private readonly Camera2BasicFragment owner;
+
+        //public File File { get; private set; }
+        //public Camera2BasicFragment Owner { get; private set; }
+
         public void OnImageAvailable(ImageReader reader)
         {
-            Owner.mBackgroundHandler.Post(new ImageSaver(reader.AcquireNextImage(), File));
+            owner.mBackgroundHandler.Post(new ImageSaver(reader.AcquireNextImage(), file));
         }
 
         // Saves a JPEG {@link Image} into the specified {@link File}.
@@ -26,6 +40,11 @@ namespace Camera2Basic.Listeners
 
             public ImageSaver(Image image, File file)
             {
+                if (image == null)
+                    throw new System.ArgumentNullException("image");
+                if (file == null)
+                    throw new System.ArgumentNullException("file");
+
                 mImage = image;
                 mFile = file;
             }


### PR DESCRIPTION
Fix #156 by registering `CameraCaptureListener` and `ImageAvailableListener` in `Camera2BasicFragment::OnActivityCreated()`.
Fix intermittent timeout issues by replacing "Microseconds" with "Milliseconds" in `mCameraOpenCloseLock.TryAcquire(2500, TimeUnit.Microseconds)`.
Classes now ensure valid references in their constructor. This change isn't strictly necessary.
