### PR TITLE
Fix stop is not a function error

### DIFF
--- a/android5.0/PermissionRequest/Assets/sample.js
+++ b/android5.0/PermissionRequest/Assets/sample.js
@@ -42,7 +42,7 @@
                     console.error('Error starting camera. Denied.');
                 });
             } else {
-                stream.stop();
+                stream.getTracks().forEach(function (track) { track.stop(); });
                 stream = null;
                 toggle.innerText = 'Start';
                 console.log('Stopped');


### PR DESCRIPTION
Fixes an issue where pressing the stop button did not stop the camera stream
See issue filed here: https://bugzilla.xamarin.com/show_bug.cgi?id=45987
Solution from: https://github.com/andyet/SimpleWebRTC/issues/363#issuecomment-163178700