### PR TITLE
Add IntentFilter for Android TV Leanback app

### DIFF
--- a/tv/TvLeanback/TvLeanback/MainActivity.cs
+++ b/tv/TvLeanback/TvLeanback/MainActivity.cs
@@ -6,9 +6,9 @@ namespace TvLeanback
 {
 	[Activity (Icon="@drawable/videos_by_google_banner", Label="@string/app_name", 
 		ScreenOrientation = Android.Content.PM.ScreenOrientation.Landscape, MainLauncher = true)]
-        [IntentFilter(
-                actions : new string[] { "android.intent.action.MAIN" },
-                Categories = new string[] { "android.intent.category.LEANBACK_LAUNCHER" })]
+	[IntentFilter(
+		actions : new string[] { "android.intent.action.MAIN" },
+		Categories = new string[] { "android.intent.category.LEANBACK_LAUNCHER" })]
 	public class MainActivity : Activity
 	{
 		protected override void OnCreate(Bundle saved)

--- a/tv/TvLeanback/TvLeanback/MainActivity.cs
+++ b/tv/TvLeanback/TvLeanback/MainActivity.cs
@@ -6,6 +6,9 @@ namespace TvLeanback
 {
 	[Activity (Icon="@drawable/videos_by_google_banner", Label="@string/app_name", 
 		ScreenOrientation = Android.Content.PM.ScreenOrientation.Landscape, MainLauncher = true)]
+        [IntentFilter(
+                actions : new string[] { "android.intent.action.MAIN" },
+                Categories = new string[] { "android.intent.category.LEANBACK_LAUNCHER" })]
 	public class MainActivity : Activity
 	{
 		protected override void OnCreate(Bundle saved)


### PR DESCRIPTION
Without this intent, the app tile will not be added to Android TV Apps' homescreen. Full documentation here: https://developer.android.com/training/tv/start/start.html#dev-project (under `Declare a TV Activity`)

> **Caution**: If you do not include the `CATEGORY_LEANBACK_LAUNCHER` intent filter in your app, it is not visible to users running Google Play on TV devices. Also, if your app does not have this filter when you use developer tools to load it onto a TV device, the app does not appear in the TV user interface. 