### PR TITLE
Fixes bug that would crash FingerprintGuide 

### DIFF
--- a/FingerprintGuide/FingerprintSampleApp/FingerprintManagerApiActivity.cs
+++ b/FingerprintGuide/FingerprintSampleApp/FingerprintManagerApiActivity.cs
@@ -48,7 +48,7 @@ namespace Xamarin.FingerprintSample
 
             if (_canScan)
             {
-                _dialogFrag = FingerprintManagerApiDialogFragment.NewInstance(_fingerprintManager);
+                _dialogFrag = FingerprintManagerApiDialogFragment.NewInstance();
             }
             else
             {
@@ -61,7 +61,7 @@ namespace Xamarin.FingerprintSample
             string canScanMsg = CheckFingerprintEligibility();
             if (_canScan)
             {
-                _dialogFrag = FingerprintManagerApiDialogFragment.NewInstance(_fingerprintManager);
+                _dialogFrag = FingerprintManagerApiDialogFragment.NewInstance();
                 _initialPanel.Visibility = ViewStates.Visible;
                 _authenticatedPanel.Visibility = ViewStates.Gone;
                 _errorPanel.Visibility = ViewStates.Gone;

--- a/FingerprintGuide/FingerprintSampleApp/FingerprintManagerApiDialogFragment.cs
+++ b/FingerprintGuide/FingerprintSampleApp/FingerprintManagerApiDialogFragment.cs
@@ -45,14 +45,8 @@ namespace Xamarin.FingerprintSample
             get { return _cancellationSignal != null; }
         }
 
-        public static FingerprintManagerApiDialogFragment NewInstance(FingerprintManagerCompat fingerprintManager)
-        {
-            FingerprintManagerApiDialogFragment frag = new FingerprintManagerApiDialogFragment
-                                                       {
-                                                           _fingerprintManager = fingerprintManager
-                                                       };
-            return frag;
-        }
+        public static FingerprintManagerApiDialogFragment NewInstance() => 
+            new FingerprintManagerApiDialogFragment();
 
         public void Init(bool startScanning = true)
         {
@@ -62,6 +56,7 @@ namespace Xamarin.FingerprintSample
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
+            _fingerprintManager = FingerprintManagerCompat.From(Context);
             RetainInstance = true;
             CryptObjectHelper = new CryptoObjectHelper();
             SetStyle(DialogFragmentStyle.Normal, Res.Style.ThemeMaterialLightDialog);


### PR DESCRIPTION
Fixes bug that would crash FingerprintGuide when fragment is shown an…d activity is recreated.
Fix consists of not passing FingerprintManagerCompat instance to fragment. It becomes null if activity is recreated when fragment is shown.
To crash existing code enable developer option "Do not keep activities", make app to show the fingerprint fragment, hide activity, make activity foreground.