### PR TITLE
Fix of error preventing build

### DIFF
--- a/android5.0/Camera2Basic/Camera2Basic/Camera2BasicFragment.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Camera2BasicFragment.cs
@@ -674,22 +674,22 @@ namespace Camera2Basic
 
         public void OnClick(View v)
         {
-            switch (v.Id)
+            if (v.Id == Resource.Id.picture)
             {
-                case Resource.Id.picture:
-                    TakePicture();
-                    break;
-                case Resource.Id.info:
-                    EventHandler<DialogClickEventArgs> nullHandler = null;
-                    Activity activity = Activity;
-                    if (activity != null)
-                    {
-                        new AlertDialog.Builder(activity)
-                            .SetMessage("This sample demonstrates the basic use of the Camera2 API. ...")
-                            .SetPositiveButton(Android.Resource.String.Ok, nullHandler)
-                            .Show();
-                    }
-                    break;
+                TakePicture();
+            }
+            else if (v.Id == Resource.Id.info)
+            {
+
+                EventHandler<DialogClickEventArgs> nullHandler = null;
+                Activity activity = Activity;
+                if (activity != null)
+                {
+                    new AlertDialog.Builder(activity)
+                        .SetMessage("This sample demonstrates the basic use of the Camera2 API. ...")
+                        .SetPositiveButton(Android.Resource.String.Ok, nullHandler)
+                        .Show();
+                }
             }
         }
 


### PR DESCRIPTION
Resource.Id.picture and Resource.Id.info are dynamically generated as static fields in Resource.Designer.cs while they are required be const in switch-case expressions. Replaced them with simple if-elseif. The issue has been already reported here https://bugzilla.xamarin.com/show_bug.cgi?id=23176