### PR TITLE
Solving #273 - Avoids multiple picture callbacks

### DIFF
--- a/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureListener.cs
+++ b/android5.0/Camera2Basic/Camera2Basic/Listeners/CameraCaptureListener.cs
@@ -34,6 +34,7 @@ namespace Camera2Basic.Listeners
                         Integer afState = (Integer)result.Get(CaptureResult.ControlAfState);
                         if (afState == null)
                         {
+                            owner.mState = Camera2BasicFragment.STATE_PICTURE_TAKEN; // avoids multiple picture callbacks
                             owner.CaptureStillPicture();
                         }
 


### PR DESCRIPTION
Implements the change proposed by @smvernon - which is a showstopper to take this example as a base for own projects: It's not easy to spot why double captures occur and how to avoid them.