### PR TITLE
[CalendarDemo] fix for aapt2 (which is now default)

### DIFF
--- a/CalendarDemo/Resources/layout/CalendarList.axml
+++ b/CalendarDemo/Resources/layout/CalendarList.axml
@@ -4,7 +4,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
     <ListView
-        android:id="@android:id/android:list"
+        android:id="@android:id/list"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" />         
 </LinearLayout>

--- a/CalendarDemo/Resources/layout/EventList.axml
+++ b/CalendarDemo/Resources/layout/EventList.axml
@@ -4,7 +4,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
     <ListView
-        android:id="@android:id/android:list"
+        android:id="@android:id/list"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" />
     <Button 


### PR DESCRIPTION
When building this project with `<AndroidUseAapt>True</AndroidUseAapt2>`
you will get:

    error APT2260: obj\Debug\44\res\layout\calendarlist.xml:1: error: resource android:id/android:list not found. "android:list not found."
    error APT2260: obj\Debug\44\res\layout\eventlist.xml:1: error: resource android:id/android:list not found. "android:list not found."

I think the name `android:id/android:list` is probably just a typo, so
removing `android:` fixes the issue.