### PR TITLE
Update minSdkVersion for projects using support libs

### DIFF
--- a/Facebook/HelloFacebookSample/Properties/AndroidManifest.xml
+++ b/Facebook/HelloFacebookSample/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.facebook.samples.hellofacebook" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="@string/app_name" android:icon="@drawable/icon" android:theme="@android:style/Theme.NoTitleBar">
 		<activity android:name="com.facebook.FacebookActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:label="@string/app_name" />
     <activity

--- a/GooglePlayServices/GooglePlayServices/Properties/AndroidManifest.xml
+++ b/GooglePlayServices/GooglePlayServices/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="GooglePlayServicesTest.GooglePlayServicesTest">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="GooglePlayServicesTest" android:icon="@drawable/icon">
 		<!-- Put your Google Maps V2 API Key here. This key will not work for you.-->
 		<!-- See https://developers.google.com/maps/documentation/android/start#obtaining_an_api_key -->

--- a/HowsMyTls/HowsMyTls/Properties/AndroidManifest.xml
+++ b/HowsMyTls/HowsMyTls/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.xiosdebugging.howsmytls">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@style/Theme.Base"></application>
 </manifest>

--- a/LeaderboardsAndAchievementsDemo/Properties/AndroidManifest.xml
+++ b/LeaderboardsAndAchievementsDemo/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.0" package="com.xamarin.samples.gameservices" android:versionCode="2">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<!-- Google Maps for Android v2 requires OpenGL ES v2 -->
 	<uses-feature android:glEsVersion="0x00020000" android:required="true" />
 	<!-- We need to be able to download map tiles and access Google Play Services-->

--- a/MonoIO/Properties/AndroidManifest.xml
+++ b/MonoIO/Properties/AndroidManifest.xml
@@ -4,6 +4,6 @@
 		<meta-data android:name="android.app.default_searchable" android:value="monoio.SearchActivity" />
 	</application>
 	<permission android:name="monoio.permission.WRITE_SCHEDULE" android:protectionLevel="normal" android:label="@string/permission_write" android:description="@string/permission_write" />
-	<uses-sdk android:minSdkVersion="10" android:targetSdkVersion="21" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/SlidingMenu/SlidingMenuExample/Properties/AndroidManifest.xml
+++ b/SlidingMenu/SlidingMenuExample/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="SlidingMenuExample.SlidingMenuExample">
-	<uses-sdk android:minSdkVersion="10" android:targetSdkVersion="21" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 	<application android:label="SlidingMenuExample">
 	</application>
 </manifest>

--- a/Support4/Support4/Properties/AndroidManifest.xml
+++ b/Support4/Support4/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Support4.Support4">
 	<application android:label="Support4" android:icon="@drawable/icon">
 	</application>
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/Supportv7/ActionBarCompat-ListPopupMenu/Properties/AndroidManifest.xml
+++ b/Supportv7/ActionBarCompat-ListPopupMenu/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.actionbarcompat_listpopupmenu">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.AppCompat" android:allowBackup="true"></application>
 </manifest>

--- a/Supportv7/AppCompat/Toolbar/Supportv7Toolbar/Properties/AndroidManifest.xml
+++ b/Supportv7/AppCompat/Toolbar/Supportv7Toolbar/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="HelloToolbar.HelloToolbar">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="HelloToolbar" android:theme="@style/MyTheme"></application>
 </manifest>

--- a/UserInterface/ActionBarTabs/ActionBarTabsSupport/Properties/AndroidManifest.xml
+++ b/UserInterface/ActionBarTabs/ActionBarTabsSupport/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.example.tabbedui">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="TabbedUI" android:icon="@drawable/ic_launcher"></application>
 </manifest>

--- a/ViewPagerIndicator/ViewPagerIndicator/Properties/AndroidManifest.xml
+++ b/ViewPagerIndicator/ViewPagerIndicator/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="ViewPagerIndicator.ViewPagerIndicator">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="MfA ViewPager Indicator" android:icon="@drawable/icon">
 	</application>
 </manifest>

--- a/google-services/AdMobExample/AdMobExample/Properties/AndroidManifest.xml
+++ b/google-services/AdMobExample/AdMobExample/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.admobexample">
-	<uses-sdk android:minSdkVersion="10" android:targetSdkVersion="21" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<application android:icon="@drawable/icon" android:label="AdMob Quickstart" android:theme="@style/AppTheme">

--- a/google-services/Analytics/Analytics/Properties/AndroidManifest.xml
+++ b/google-services/Analytics/Analytics/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.analytics">
-	<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="21" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application />

--- a/google-services/Fitness/BasicHistoryApi/BasicHistoryApi/Properties/AndroidManifest.xml
+++ b/google-services/Fitness/BasicHistoryApi/BasicHistoryApi/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.basichistoryapi">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/AppTheme"></application>
 </manifest>

--- a/google-services/Fitness/BasicHistorySessions/BasicHistorySessions/Properties/AndroidManifest.xml
+++ b/google-services/Fitness/BasicHistorySessions/BasicHistorySessions/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.basichistorysessions">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/AppTheme"></application>
 </manifest>

--- a/google-services/Fitness/BasicSensorsApi/BasicSensorsApi/Properties/AndroidManifest.xml
+++ b/google-services/Fitness/BasicSensorsApi/BasicSensorsApi/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.basicsensorsapi">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/AppTheme"></application>
 </manifest>

--- a/google-services/GCMSample/GCMSample/Properties/AndroidManifest.xml
+++ b/google-services/GCMSample/GCMSample/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.gcmquickstart">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.INTERNET" />

--- a/google-services/Location/ActivityRecognition/ActivityRecognition/Properties/AndroidManifest.xml
+++ b/google-services/Location/ActivityRecognition/ActivityRecognition/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.activityrecognition">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.Base">
 		<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
 	</application>

--- a/google-services/Location/BasicLocationSample/BasicLocationSample/Properties/AndroidManifest.xml
+++ b/google-services/Location/BasicLocationSample/BasicLocationSample/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.basiclocationsample">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.Base"></application>
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>

--- a/google-services/Location/Geofencing/Geofencing/Properties/AndroidManifest.xml
+++ b/google-services/Location/Geofencing/Geofencing/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.geofencing">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.Base"></application>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/google-services/Location/LocationAddress/LocationAddress/Properties/AndroidManifest.xml
+++ b/google-services/Location/LocationAddress/LocationAddress/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.locationaddress">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.Base"></application>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/google-services/Location/LocationSettings/LocationSettings/Properties/AndroidManifest.xml
+++ b/google-services/Location/LocationSettings/LocationSettings/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.locationsettings">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/google-services/Location/LocationUpdates/LocationUpdates/Properties/AndroidManifest.xml
+++ b/google-services/Location/LocationUpdates/LocationUpdates/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.locationupdates" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="10" />
+	<uses-sdk android:minSdkVersion="16" />
 	<application android:allowBackup="true" android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/AppTheme"></application>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>


### PR DESCRIPTION
API 16 is the lowest version of Android that is officially supported by
Xamarin.Android. In most cases, this restriction is only presented as a
build warning. Recent changes to use Google's [manifest merger tool][0]
have however surfaced a [new error][1] in projects which use the support
libraries and specify a minSdkVersion lower than API 14. These projects
should be updated to use a minSdkVersion of 16 to avoid both this new
error, and the existing warning about using an unsupported minimum SDK
version.

[0]: https://github.com/xamarin/xamarin-android/commit/2c6f5cd16fb5087731107c1defa13ebb56cf63df
[1]: https://dev.azure.com/devdiv/DevDiv/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?_a=release-pipeline-progress&releaseId=528620