### PR TITLE
Fix obsolete API usage

### DIFF
--- a/HoneycombGallery/CameraFragment.cs
+++ b/HoneycombGallery/CameraFragment.cs
@@ -16,14 +16,13 @@
 
 using System;
 using System.Collections.Generic;
-using Android.Graphics;
 using Java.IO;
 using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Util;
 using Android.Views;
-using Camera = Android.Hardware.Camera;
+using Android.Hardware;
 
 namespace com.example.monodroid.hcgallery
 {
@@ -54,7 +53,7 @@ namespace com.example.monodroid.hcgallery
 			Camera.CameraInfo cameraInfo = new Camera.CameraInfo ();
 			for (int i = 0; i < mNumberOfCameras; i++) {
 				Camera.GetCameraInfo (i, cameraInfo);
-				if (cameraInfo.Facing == Camera.CameraInfo.CameraFacingBack) {
+				if (cameraInfo.Facing == CameraFacing.Back) {
 					mDefaultCameraId = i;
 				}
 			}

--- a/PlatformFeatures/ICS_Samples/SystemUIVisibilityDemo/SystemUIVisibilityDemo/Activity1.cs
+++ b/PlatformFeatures/ICS_Samples/SystemUIVisibilityDemo/SystemUIVisibilityDemo/Activity1.cs
@@ -26,15 +26,15 @@ namespace SystemUIVisibilityDemo
             var visibleButton = FindViewById<Button> (Resource.Id.visibleButton);
             
             lowProfileButton.Click += delegate { 
-                tv.SystemUiVisibility = (StatusBarVisibility)View.SystemUiFlagLowProfile;
+                tv.SystemUiVisibility = (StatusBarVisibility)SystemUiFlags.LowProfile;
             };
             
             hideNavButton.Click += delegate {
-                tv.SystemUiVisibility = (StatusBarVisibility)View.SystemUiFlagHideNavigation;         
+                tv.SystemUiVisibility = (StatusBarVisibility)SystemUiFlags.HideNavigation;
             };
             
             visibleButton.Click += delegate {
-                tv.SystemUiVisibility = (StatusBarVisibility)View.SystemUiFlagVisible;
+                tv.SystemUiVisibility = (StatusBarVisibility)SystemUiFlags.Visible;
             };
             
             tv.SystemUiVisibilityChange += delegate(object sender, View.SystemUiVisibilityChangeEventArgs e) {

--- a/UrbanAirship/samples/PushSample/CustomPreferencesActivity.cs
+++ b/UrbanAirship/samples/PushSample/CustomPreferencesActivity.cs
@@ -182,14 +182,14 @@ namespace PushSample
 
 				// Grab the start date.
 				Calendar cal = Calendar.Instance;
-				cal.Set(Calendar.HourOfDay, (int) startTime.CurrentHour);
-				cal.Set(Calendar.Minute, (int) startTime.CurrentMinute);
+				cal.Set(CalendarField.HourOfDay, (int) startTime.CurrentHour);
+				cal.Set(CalendarField.Minute, (int) startTime.CurrentMinute);
 				Date startDate = cal.Time;
 
 				// Prepare the end date.
 				cal = Calendar.Instance;
-				cal.Set(Calendar.HourOfDay, (int) endTime.CurrentHour);
-				cal.Set(Calendar.Minute, (int) endTime.CurrentMinute);
+				cal.Set(CalendarField.HourOfDay, (int) endTime.CurrentHour);
+				cal.Set(CalendarField.Minute, (int) endTime.CurrentMinute);
 				Date endDate = cal.Time;
 
 				pushPrefs.SetQuietTimeInterval (startDate, endDate);

--- a/android-o/AndroidCipher/AndroidCipher/AndroidCipher.cs
+++ b/android-o/AndroidCipher/AndroidCipher/AndroidCipher.cs
@@ -6,9 +6,6 @@ using Javax.Crypto.Spec;
 using System.Text;
 using Android.Util;
 using Java.Security.Spec;
-using static System.Text.Encoding;
-using static Android.Util.Base64;
-using static Javax.Crypto.Cipher;
 
 namespace AndroidCipher
 {
@@ -27,11 +24,11 @@ namespace AndroidCipher
 
         public void Decryption(object sender, EventArgs eventArgs)
         {
-            var decipher = GetInstance(Constants.Transformation);
+            var decipher = Cipher.GetInstance(Constants.Transformation);
             var algorithmParameterSpec = (IAlgorithmParameterSpec)_encipher.Parameters.GetParameterSpec(Java.Lang.Class.FromType(typeof(GCMParameterSpec)));
-            decipher.Init(DecryptMode, _secretKey, algorithmParameterSpec);
+            decipher.Init(CipherMode.DecryptMode, _secretKey, algorithmParameterSpec);
 
-            byte[] decodedValue = Decode(UTF8.GetBytes(_activity.textOutput.Text), Base64.Default);
+            byte[] decodedValue = Base64.Decode(Encoding.UTF8.GetBytes(_activity.textOutput.Text), Base64Flags.Default);
             byte[] decryptedVal = decipher.DoFinal(decodedValue);
             _activity.textOriginal.Text = Encoding.Default.GetString(decryptedVal);
         }
@@ -47,12 +44,12 @@ namespace AndroidCipher
             _secretKey = GenerateKey();
             if (ValidateInput(_activity.textInput.Text)) return;
 
-            _encipher = GetInstance(Constants.Transformation);
-            _encipher.Init(EncryptMode, _secretKey, GenerateGcmParameterSpec());
+            _encipher = Cipher.GetInstance(Constants.Transformation);
+            _encipher.Init(CipherMode.EncryptMode, _secretKey, GenerateGcmParameterSpec());
 
             byte[]
-            results = _encipher.DoFinal(UTF8.GetBytes(_activity.textInput.Text));
-            _activity.textOutput.Text = EncodeToString(results, Base64.Default);
+            results = _encipher.DoFinal(Encoding.UTF8.GetBytes(_activity.textInput.Text));
+            _activity.textOutput.Text = Base64.EncodeToString(results, Base64Flags.Default);
         }
 
         private bool ValidateInput(string input)

--- a/android-o/AndroidCipher/AndroidCipher/AndroidCipher.csproj
+++ b/android-o/AndroidCipher/AndroidCipher/AndroidCipher.csproj
@@ -16,7 +16,6 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/android-o/AndroidPlayLocation/LocUpdFgService/LocUpdFgService/LocUpdFgService.csproj
+++ b/android-o/AndroidPlayLocation/LocUpdFgService/LocUpdFgService/LocUpdFgService.csproj
@@ -16,7 +16,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/android-o/AndroidPlayLocation/LocUpdFgService/LocUpdFgService/LocationUpdatesService.cs
+++ b/android-o/AndroidPlayLocation/LocUpdFgService/LocUpdFgService/LocationUpdatesService.cs
@@ -121,10 +121,10 @@ namespace LocUpdFgService
 			ServiceHandler = new Handler(handlerThread.Looper);
 			NotificationManager = (NotificationManager) GetSystemService(NotificationService);
 
-		    if (Build.VERSION.SdkInt >= Build.VERSION_CODES.O)
+		    if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
 		    {
 		        string name = GetString(Resource.String.app_name);
-		        NotificationChannel mChannel = new NotificationChannel(ChannelId, name, NotificationManager.ImportanceDefault);
+		        NotificationChannel mChannel = new NotificationChannel(ChannelId, name, NotificationImportance.Default);
 		        NotificationManager.CreateNotificationChannel(mChannel);
 		    }
         }
@@ -269,7 +269,7 @@ namespace LocUpdFgService
                 .SetTicker(text)
                 .SetWhen(JavaSystem.CurrentTimeMillis());
 
-            if (Build.VERSION.SdkInt>= Build.VERSION_CODES.O)
+            if (Build.VERSION.SdkInt>= BuildVersionCodes.O)
             {
                 builder.SetChannelId(ChannelId);
             }

--- a/android-o/AndroidPlayLocation/LocUpdPendIntent/LocUpdPendIntent/LocUpdPendIntent.csproj
+++ b/android-o/AndroidPlayLocation/LocUpdPendIntent/LocUpdPendIntent/LocUpdPendIntent.csproj
@@ -16,7 +16,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/android-o/AndroidPlayLocation/LocUpdPendIntent/LocUpdPendIntent/Utils.cs
+++ b/android-o/AndroidPlayLocation/LocUpdPendIntent/LocUpdPendIntent/Utils.cs
@@ -78,12 +78,12 @@ namespace LocUpdPendIntent
 			var mNotificationManager = context.GetSystemService(Context.NotificationService) as NotificationManager;
 
 		    // Android O requires a Notification Channel.
-		    if (Build.VERSION.SdkInt>= Build.VERSION_CODES.O)
+		    if (Build.VERSION.SdkInt>= BuildVersionCodes.O)
 		    {
 		        string name = context.GetString(Resource.String.app_name);
 		        // Create the channel for the notification
 		        // Create the channel for the notification
-		        NotificationChannel mChannel = new NotificationChannel(ChannelId, name, NotificationManager.ImportanceDefault);
+		        NotificationChannel mChannel = new NotificationChannel(ChannelId, name, NotificationImportance.Default);
 
 		        // Set the Notification Channel for the Notification Manager.
 		        mNotificationManager.CreateNotificationChannel(mChannel);

--- a/android-o/AutofillFramework/AutofillFramework/AutofillFramework.csproj
+++ b/android-o/AutofillFramework/AutofillFramework/AutofillFramework.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/android-o/AutofillFramework/AutofillFramework/CreditCardExpirationDateCompoundView.cs
+++ b/android-o/AutofillFramework/AutofillFramework/CreditCardExpirationDateCompoundView.cs
@@ -43,12 +43,12 @@ namespace AutofillFramework
             var rootView = LayoutInflater.From(context).Inflate(Resource.Layout.cc_exp_date, this);
             mCcExpMonthSpinner = rootView.FindViewById<Spinner>(Resource.Id.ccExpMonth);
             mCcExpYearSpinner = rootView.FindViewById<Spinner>(Resource.Id.ccExpYear);
-            ImportantForAutofill = ImportantForAutofillYesExcludeDescendants;
+            ImportantForAutofill = ImportantForAutofill.YesExcludeDescendants;
             var monthAdapter = ArrayAdapter.CreateFromResource(context, Resource.Array.month_array,
                 Android.Resource.Layout.SimpleSpinnerItem);
             monthAdapter.SetDropDownViewResource(Android.Resource.Layout.SimpleSpinnerDropDownItem);
             mCcExpMonthSpinner.Adapter = monthAdapter;
-            int year = Calendar.Instance.Get(Calendar.Year);
+            int year = Calendar.Instance.Get(CalendarField.Year);
             for (int i = 0; i < mYears.Length; i++)
             {
                 mYears[i] = (year + i).ToString();
@@ -92,8 +92,8 @@ namespace AutofillFramework
                 calendar.Clear();
                 var year = Integer.ParseInt(mCcExpYearSpinner.SelectedItem.ToString());
                 var month = mCcExpMonthSpinner.SelectedItemPosition;
-                calendar.Set(Calendar.Year, year);
-                calendar.Set(Calendar.Month, month);
+                calendar.Set(CalendarField.Year, year);
+                calendar.Set(CalendarField.Month, month);
                 var unixTime = calendar.TimeInMillis;
                 return AutofillValue.ForDate(unixTime);
             }
@@ -109,8 +109,8 @@ namespace AutofillFramework
 
             var calendar = Calendar.Instance;
             calendar.TimeInMillis = value.DateValue;
-            var month = calendar.Get(Calendar.Month);
-            var year = calendar.Get(Calendar.Year);
+            var month = calendar.Get(CalendarField.Month);
+            var year = calendar.Get(CalendarField.Year);
             mCcExpMonthSpinner.SetSelection(month);
             mCcExpYearSpinner.SetSelection(year - Integer.ParseInt(mYears[0]));
         }

--- a/android-o/AutofillFramework/AutofillFramework/CreditCardExpirationDatePickerView.cs
+++ b/android-o/AutofillFramework/AutofillFramework/CreditCardExpirationDatePickerView.cs
@@ -45,8 +45,8 @@ namespace AutofillFramework
         {
             // Use the current date as the initial date in the picker.
             mTempCalendar = Calendar.Instance;
-            mYear = mTempCalendar.Get(Calendar.Year);
-            mMonth = mTempCalendar.Get(Calendar.Month);
+            mYear = mTempCalendar.Get(CalendarField.Year);
+            mMonth = mTempCalendar.Get(CalendarField.Month);
         }
 
         /**
@@ -55,9 +55,9 @@ namespace AutofillFramework
         private Calendar GetCalendar()
         {
             mTempCalendar.Clear();
-            mTempCalendar.Set(Calendar.Year, mYear);
-            mTempCalendar.Set(Calendar.Month, mMonth);
-            mTempCalendar.Set(Calendar.Date, 1);
+            mTempCalendar.Set(CalendarField.Year, mYear);
+            mTempCalendar.Set(CalendarField.Month, mMonth);
+            mTempCalendar.Set(CalendarField.Date, 1);
             return mTempCalendar;
         }
 
@@ -81,8 +81,8 @@ namespace AutofillFramework
             }
             var time = value.DateValue;
             mTempCalendar.TimeInMillis = time;
-            var year = mTempCalendar.Get(Calendar.Year);
-            var month = mTempCalendar.Get(Calendar.Month);
+            var year = mTempCalendar.Get(CalendarField.Year);
+            var month = mTempCalendar.Get(CalendarField.Month);
             if (CommonUtil.DEBUG) Log.Debug(CommonUtil.TAG, "autofill(" + value + "): " + month + "/" + year);
             SetDate(year, month);
         }
@@ -101,7 +101,7 @@ namespace AutofillFramework
         public void Reset()
         {
             mTempCalendar.TimeInMillis = DateTime.Now.Millisecond;
-            SetDate(mTempCalendar.Get(Calendar.Year), mTempCalendar.Get(Calendar.Month));
+            SetDate(mTempCalendar.Get(CalendarField.Year), mTempCalendar.Get(CalendarField.Month));
         }
 
         public void ShowDatePickerDialog(FragmentManager fragmentManager)
@@ -126,7 +126,7 @@ namespace AutofillFramework
                 // Limit range.
                 Calendar c = mParent.GetCalendar();
                 datePicker.MinDate = c.TimeInMillis;
-                c.Set(Calendar.Year, mParent.mYear + CC_EXP_YEARS_COUNT - 1);
+                c.Set(CalendarField.Year, mParent.mYear + CC_EXP_YEARS_COUNT - 1);
                 datePicker.MaxDate = c.TimeInMillis;
 
                 // Remove day.

--- a/android-o/AutofillFramework/AutofillFramework/CreditCardSpinnersActivity.cs
+++ b/android-o/AutofillFramework/AutofillFramework/CreditCardSpinnersActivity.cs
@@ -64,7 +64,7 @@ namespace AutofillFramework
             monthAdapter.SetDropDownViewResource(Android.Resource.Layout.SimpleSpinnerDropDownItem);
             mCcExpirationMonthSpinner.Adapter = monthAdapter;
 
-            int year = Java.Util.Calendar.Instance.Get(Java.Util.Calendar.Year);
+            int year = Java.Util.Calendar.Instance.Get(Java.Util.CalendarField.Year);
             for (int i = 0; i < years.Length; i++)
             {
                 years[i] = (year + i).ToString();

--- a/android-o/AutofillFramework/AutofillService/AutofillHints.cs
+++ b/android-o/AutofillFramework/AutofillService/AutofillHints.cs
@@ -5,7 +5,7 @@ using Android.Service.Autofill;
 using Android.Util;
 using Android.Views;
 using AutofillService.Model;
-using static Android.Icu.Util.Calendar;
+using static Android.Icu.Util.CalendarField;
 
 namespace AutofillService
 {
@@ -805,7 +805,7 @@ namespace AutofillService
             public FilledAutofillField Generate(int seed)
             {
                 var filledAutofillField = new FilledAutofillField(Type);
-                var calendar = Instance;
+                var calendar = Android.Icu.Util.Calendar.Instance;
                 calendar.Set(Year, calendar.Get(Year) + seed);
                 filledAutofillField.SetDateValue(calendar.TimeInMillis);
                 return filledAutofillField;
@@ -825,7 +825,7 @@ namespace AutofillService
             {
                 var months = MonthRange();
                 int month = seed % months.Length;
-                var calendar = Instance;
+                var calendar = Android.Icu.Util.Calendar.Instance;
                 calendar.Set(Month, month);
                 var filledAutofillField = new FilledAutofillField(Type);
                 filledAutofillField.SetListValue(months, month);
@@ -847,7 +847,7 @@ namespace AutofillService
             public FilledAutofillField Generate(int seed)
             {
                 FilledAutofillField filledAutofillField = new FilledAutofillField(Type);
-                var calendar = Instance;
+                var calendar = Android.Icu.Util.Calendar.Instance;
                 int expYear = calendar.Get(Year) + seed;
                 calendar.Set(Year, expYear);
                 filledAutofillField.SetDateValue(calendar.TimeInMillis);
@@ -870,7 +870,7 @@ namespace AutofillService
                 var days = DayRange();
                 int day = seed % days.Length;
                 var filledAutofillField = new FilledAutofillField(Type);
-                var calendar = Instance;
+                var calendar = Android.Icu.Util.Calendar.Instance;
                 calendar.Set(Date, day);
                 filledAutofillField.SetListValue(days, day);
                 filledAutofillField.SetTextValue(day.ToString());
@@ -891,7 +891,7 @@ namespace AutofillService
             public FilledAutofillField Generate(int seed)
             {
                 var filledAutofillField = new FilledAutofillField(Type);
-                int year = Instance.Get(Year) - seed * 10;
+                int year = Android.Icu.Util.Calendar.Instance.Get(Year) - seed * 10;
                 filledAutofillField.SetTextValue("" + year);
                 return filledAutofillField;
             }
@@ -909,7 +909,7 @@ namespace AutofillService
             public FilledAutofillField Generate(int seed)
             {
                 var filledAutofillField = new FilledAutofillField(Type);
-                var calendar = Instance;
+                var calendar = Android.Icu.Util.Calendar.Instance;
                 calendar.Set(Year, calendar.Get(Year) - seed * 10);
                 calendar.Set(Month, seed % 12);
                 calendar.Set(Date, seed % 27);

--- a/android-o/AutofillFramework/AutofillService/AutofillService.csproj
+++ b/android-o/AutofillFramework/AutofillService/AutofillService.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/commit/fefe0cad
Context: https://dev.azure.com/devdiv/DevDiv/_releaseProgress?releaseId=654124&_a=release-environment-extension&environmentId=3567428&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab

These projects have been failing to build against Xamarin.Android d16-6,
and they can be fixed by updating their usage of obsolete APIs.