### PR TITLE
Expose private nested types that are exposed in public API.

### DIFF
--- a/OsmDroidBindingExample/OsmDroidBinding/Transforms/Metadata.xml
+++ b/OsmDroidBindingExample/OsmDroidBinding/Transforms/Metadata.xml
@@ -23,6 +23,8 @@
 	<attr path="/api/package[@name='org.osmdroid.tileprovider']/class[@name='MapTileProviderBase.ScaleTileLooper']/method[@name='handleTile']" name="visibility">public</attr>
 	<attr path="/api/package[@name='org.osmdroid.tileprovider']/class[@name='MapTileProviderBase.ZoomInTileLooper']/method[@name='handleTile']" name="visibility">public</attr>
 	<attr path="/api/package[@name='org.osmdroid.tileprovider']/class[@name='MapTileProviderBase.ZoomOutTileLooper']/method[@name='handleTile']" name="visibility">public</attr>
+	<attr path="/api/package[@name='org.osmdroid.views']/class[@name='MapControllerOld.CosinusalBasedAnimationRunner']" name="visibility">public</attr>
+	<attr path="/api/package[@name='org.osmdroid.events']/class[@name='DelayedMapListener.CallbackTask']" name="visibility">public</attr>
 	<!-- Draw() seems to be public for android so we need to be consistent about it.  C# doesn't like to mix visibility during inheritance. -->
 	<attr path="/api/package[@name='org.osmdroid.views.overlay']/class[@name='Overlay']/method[@name='draw']" name="visibility">public</attr>
 	<attr path="/api/package[@name='org.osmdroid.views.overlay']/class[@name='TilesOverlay']/method[@name='draw']" name="visibility">public</attr>

--- a/android5.0/GoogleIO2014Master/AndroidSvg/Transforms/Metadata.xml
+++ b/android5.0/GoogleIO2014Master/AndroidSvg/Transforms/Metadata.xml
@@ -27,5 +27,6 @@
   <attr path="/api/package[@name='com.caverock.androidsvg']/class[@name='SVG.TextContainer']" name="visibility">public</attr>
   <attr path="/api/package[@name='com.caverock.androidsvg']/class[@name='SVG.SvgConditionalContainer']" name="visibility">public</attr>
   <attr path="/api/package[@name='com.caverock.androidsvg']/class[@name='SVG.SvgElement']" name="visibility">public</attr>
+  <attr path="/api/package[@name='com.caverock.androidsvg']/class[@name='CSSParser.AttribOp']" name="visibility">public</attr>
 
 </metadata>


### PR DESCRIPTION
In Xamarin.Android we fixed an issue where private nested classes were getting unintentionally bound.  However, thanks to Java's lax rules regarding visibility, you can reference those classes in public API.  C# does not allow you to do this, so you need to expose the class as `public` so it will be bound and thus usable.

This updates 2 samples that were relying on exposing private nested classes to explicitly mark then as public via metadata.