### PR TITLE
Update san angeles ndk to vs2022

### DIFF
--- a/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngeles/Properties/AndroidManifest.xml
+++ b/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngeles/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="SanAngeles.SanAngeles">
-	<uses-sdk />
+	<uses-sdk android:targetSdkVersion="33" />
 	<application android:label="SanAngeles"></application>
 </manifest>

--- a/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngeles/SanAngeles.csproj
+++ b/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngeles/SanAngeles.csproj
@@ -28,7 +28,7 @@
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
     <AndroidLinkSkip />
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
     <BundleAssemblies>False</BundleAssemblies>
     <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>

--- a/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngeles/SanAngeles.csproj
+++ b/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngeles/SanAngeles.csproj
@@ -14,7 +14,6 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>

--- a/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngelesLibrary/SanAngelesLibrary.vcxproj
+++ b/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngelesLibrary/SanAngelesLibrary.vcxproj
@@ -34,7 +34,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>Clang_3_8</PlatformToolset>
+    <PlatformToolset>Clang_5_0</PlatformToolset>
+    <UseOfStl>c++_shared</UseOfStl>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngelesLibrary/SanAngelesLibrary.vcxproj
+++ b/SanAngeles_NDK/SanAngeles_NativeDebug/SanAngelesLibrary/SanAngelesLibrary.vcxproj
@@ -22,28 +22,29 @@
     <ProjectGuid>{42aaaf21-3054-4a5c-9500-01cb43da0543}</ProjectGuid>
     <Keyword>Android</Keyword>
     <ApplicationType>Android</ApplicationType>
-    <ApplicationTypeRevision>1.0</ApplicationTypeRevision>
+    <ApplicationTypeRevision>3.0</ApplicationTypeRevision>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>Clang_3_4</PlatformToolset>
+    <PlatformToolset>Clang_3_8</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>Clang_3_4</PlatformToolset>
+    <PlatformToolset>Clang_3_8</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>Clang_3_4</PlatformToolset>
+    <PlatformToolset>Clang_3_8</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>Clang_3_4</PlatformToolset>
+    <PlatformToolset>Clang_3_8</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />


### PR DESCRIPTION
These changes get the demo to run (See #349). However, if I try to change the debugger to "Native" (C++), I get a Visual Studio error):
![Screen Shot 2023-01-28 at 9 59 39 AM](https://user-images.githubusercontent.com/6641266/215293168-e31b0442-0de4-478d-8e39-ccd9b8b17e7d.png)


That error seems to be the same as this Visual Studio Developer community issue: https://developercommunity.visualstudio.com/t/Xamarin-Android-NDK-missing-registry-key/10044363?q=%22Ensure+that+support+for+multi-device+C%2B%2B+development+is+enabled+in+Visual+Studio+setup%22+%22NDK_HOME%22+debug
