### PR TITLE
Remove sample metadata

### DIFF
--- a/Button/Button/README.md
+++ b/Button/Button/README.md
@@ -1,16 +1,3 @@
----
-name: .NET for Android - Button Widget
-description: "Shows how to use a simple button widget (UI)"
-page_type: sample
-languages:
-- csharp
-products:
-- dotnet-android
-extensions:
-    tags:
-    - ui
-urlFragment: button
----
 # Button Widget
 
 Shows how to use a simple button widget - see the [documentation](https://docs.microsoft.com/xamarin/android/user-interface/controls/buttons/).

--- a/LocalNotifications/README.md
+++ b/LocalNotifications/README.md
@@ -1,13 +1,3 @@
----
-name: .NET for Android - Android Local Notifications Sample
-description: This sample app accompanies the article Using Local Notifications in .NET for Android.
-page_type: sample
-languages:
-- csharp
-products:
-- dotnet-android
-urlFragment: localnotifications
----
 # Android Local Notifications Sample
 
 This sample app accompanies the article,

--- a/Phoneword/README.md
+++ b/Phoneword/README.md
@@ -1,16 +1,3 @@
----
-name: .NET for Android - Phoneword
-description: "Sample app for the article, Hello, Android (Quickstart). This version of Phoneword incorporates all of the functionality... (get started)"
-page_type: sample
-languages:
-- csharp
-products:
-- dotnet-android
-extensions:
-    tags:
-    - getstarted
-urlFragment: phoneword
----
 # Phoneword
 
 This sample app accompanies the article,

--- a/PopupMenuDemo/README.md
+++ b/PopupMenuDemo/README.md
@@ -1,13 +1,3 @@
----
-name: .NET for Android - Popup Menu
-description: "Demonstrates how to add support for displaying popup menus that are attached to a particular view"
-page_type: sample
-languages:
-- csharp
-products:
-- dotnet-android
-urlFragment: popupmenudemo
----
 # Popup Menu Demo
 
 **PopupMenuDemo** is a sample app that accompanies the article,

--- a/SwitchDemo/README.md
+++ b/SwitchDemo/README.md
@@ -1,16 +1,3 @@
----
-name: .NET for Android - Switch Demo
-description: "Shows how to use a switch control"
-page_type: sample
-languages:
-- csharp
-products:
-- dotnet-android
-extensions:
-    tags:
-    - ui
-urlFragment: switchdemo
----
 # Switch Demo
 
 This sample app accompanies the article,


### PR DESCRIPTION
Remove the sample metadata so that we can remove the Xamarin.Android samples from the samples browser.

Once that succeeds I'll replace the sample metadata.